### PR TITLE
🆙 Bump setuptools to 70.0.0 + Fix container tests + Broken CICD

### DIFF
--- a/.github/workflows/cicd-docker-test.yml
+++ b/.github/workflows/cicd-docker-test.yml
@@ -18,6 +18,6 @@ jobs:
         run: docker images
 
       - name: Run docker tests
-        uses: docker://gcr.io/gcp-runtimes/container-structure-test:f3b74dfc21a2cdb7eb7bd94b62dcf6519926a195 # v1.19.1
+        uses: docker://gcr.io/gcp-runtimes/container-structure-test:1.19.1@sha256:e991491408e7e5f76b97a5a8efc99513e535c96f15cf1c00ac80327dd4d034cb
         with:
           args: "test --image image-test --config docker-test.yaml"

--- a/.github/workflows/cicd-docker-test.yml
+++ b/.github/workflows/cicd-docker-test.yml
@@ -18,6 +18,6 @@ jobs:
         run: docker images
 
       - name: Run docker tests
-        uses: docker://gcr.io/gcp-runtimes/container-structure-test:1.19.1@sha256:e991491408e7e5f76b97a5a8efc99513e535c96f15cf1c00ac80327dd4d034cb
+        uses: docker://gcr.io/gcp-runtimes/container-structure-test:1.19.1
         with:
           args: "test --image image-test --config docker-test.yaml"

--- a/.github/workflows/cicd-docker-test.yml
+++ b/.github/workflows/cicd-docker-test.yml
@@ -18,6 +18,6 @@ jobs:
         run: docker images
 
       - name: Run docker tests
-        uses: docker://gcr.io/gcp-runtimes/container-structure-test:1.19.1
+        uses: docker://ghcr.io/googlecontainertools/container-structure-test:1.19.1
         with:
           args: "test --image image-test --config docker-test.yaml"

--- a/.github/workflows/cicd-docker-test.yml
+++ b/.github/workflows/cicd-docker-test.yml
@@ -18,6 +18,6 @@ jobs:
         run: docker images
 
       - name: Run docker tests
-        uses: docker://ghcr.io/googlecontainertools/container-structure-test:1.19.1
+        uses: docker://ghcr.io/googlecontainertools/container-structure-test:1.19.1@sha256:e991491408e7e5f76b97a5a8efc99513e535c96f15cf1c00ac80327dd4d034cb
         with:
           args: "test --image image-test --config docker-test.yaml"

--- a/.github/workflows/cicd-tests.yml
+++ b/.github/workflows/cicd-tests.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.12"
           cache: "pipenv"
       - name: Install Pipenv
         run: pip install pipenv

--- a/Pipfile
+++ b/Pipfile
@@ -14,6 +14,7 @@ requests = "==2.32.0"
 sentry-sdk = "==2.8.0"
 freezegun = "==1.5.1"
 argparse = "*"
+setuptools = "==70.0.0"
 
 [dev-packages]
 

--- a/Pipfile
+++ b/Pipfile
@@ -3,6 +3,11 @@ url = "https://pypi.org/simple"
 verify_ssl = true
 name = "pypi"
 
+[scripts]
+list_outdated = "pip list --outdated"
+tests = "coverage run -m unittest"
+tests_report = "coverage report --omit=./test/** --sort=cover --show-missing --skip-empty"
+
 [packages]
 email-validator = "==2.1.0.post1"
 flask = "==3.0.2"

--- a/Pipfile
+++ b/Pipfile
@@ -22,6 +22,7 @@ argparse = "*"
 setuptools = "==70.0.0"
 
 [dev-packages]
+coverage = "==7.4.4"
 
 [requires]
 python_version = "3.12"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "6523d852957dd4501f1f26f2fbbb15b298a712703a26077f1252bf7ff11f91b0"
+            "sha256": "752e96f4c887307a325163f5be778a2f6b48575937ee05615b0721f3f6e9b697"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -520,5 +520,65 @@
             "version": "==1.16.0"
         }
     },
-    "develop": {}
+    "develop": {
+        "coverage": {
+            "hashes": [
+                "sha256:00838a35b882694afda09f85e469c96367daa3f3f2b097d846a7216993d37f4c",
+                "sha256:0513b9508b93da4e1716744ef6ebc507aff016ba115ffe8ecff744d1322a7b63",
+                "sha256:09c3255458533cb76ef55da8cc49ffab9e33f083739c8bd4f58e79fecfe288f7",
+                "sha256:09ef9199ed6653989ebbcaacc9b62b514bb63ea2f90256e71fea3ed74bd8ff6f",
+                "sha256:09fa497a8ab37784fbb20ab699c246053ac294d13fc7eb40ec007a5043ec91f8",
+                "sha256:0f9f50e7ef2a71e2fae92774c99170eb8304e3fdf9c8c3c7ae9bab3e7229c5cf",
+                "sha256:137eb07173141545e07403cca94ab625cc1cc6bc4c1e97b6e3846270e7e1fea0",
+                "sha256:1f384c3cc76aeedce208643697fb3e8437604b512255de6d18dae3f27655a384",
+                "sha256:201bef2eea65e0e9c56343115ba3814e896afe6d36ffd37bab783261db430f76",
+                "sha256:38dd60d7bf242c4ed5b38e094baf6401faa114fc09e9e6632374388a404f98e7",
+                "sha256:3b799445b9f7ee8bf299cfaed6f5b226c0037b74886a4e11515e569b36fe310d",
+                "sha256:3ea79bb50e805cd6ac058dfa3b5c8f6c040cb87fe83de10845857f5535d1db70",
+                "sha256:40209e141059b9370a2657c9b15607815359ab3ef9918f0196b6fccce8d3230f",
+                "sha256:41c9c5f3de16b903b610d09650e5e27adbfa7f500302718c9ffd1c12cf9d6818",
+                "sha256:54eb8d1bf7cacfbf2a3186019bcf01d11c666bd495ed18717162f7eb1e9dd00b",
+                "sha256:598825b51b81c808cb6f078dcb972f96af96b078faa47af7dfcdf282835baa8d",
+                "sha256:5fc1de20b2d4a061b3df27ab9b7c7111e9a710f10dc2b84d33a4ab25065994ec",
+                "sha256:623512f8ba53c422fcfb2ce68362c97945095b864cda94a92edbaf5994201083",
+                "sha256:690db6517f09336559dc0b5f55342df62370a48f5469fabf502db2c6d1cffcd2",
+                "sha256:69eb372f7e2ece89f14751fbcbe470295d73ed41ecd37ca36ed2eb47512a6ab9",
+                "sha256:73bfb9c09951125d06ee473bed216e2c3742f530fc5acc1383883125de76d9cd",
+                "sha256:742a76a12aa45b44d236815d282b03cfb1de3b4323f3e4ec933acfae08e54ade",
+                "sha256:7c95949560050d04d46b919301826525597f07b33beba6187d04fa64d47ac82e",
+                "sha256:8130a2aa2acb8788e0b56938786c33c7c98562697bf9f4c7d6e8e5e3a0501e4a",
+                "sha256:8a2b2b78c78293782fd3767d53e6474582f62443d0504b1554370bde86cc8227",
+                "sha256:8ce1415194b4a6bd0cdcc3a1dfbf58b63f910dcb7330fe15bdff542c56949f87",
+                "sha256:9ca28a302acb19b6af89e90f33ee3e1906961f94b54ea37de6737b7ca9d8827c",
+                "sha256:a4cdc86d54b5da0df6d3d3a2f0b710949286094c3a6700c21e9015932b81447e",
+                "sha256:aa5b1c1bfc28384f1f53b69a023d789f72b2e0ab1b3787aae16992a7ca21056c",
+                "sha256:aadacf9a2f407a4688d700e4ebab33a7e2e408f2ca04dbf4aef17585389eff3e",
+                "sha256:ae71e7ddb7a413dd60052e90528f2f65270aad4b509563af6d03d53e979feafd",
+                "sha256:b14706df8b2de49869ae03a5ccbc211f4041750cd4a66f698df89d44f4bd30ec",
+                "sha256:b1a93009cb80730c9bca5d6d4665494b725b6e8e157c1cb7f2db5b4b122ea562",
+                "sha256:b2991665420a803495e0b90a79233c1433d6ed77ef282e8e152a324bbbc5e0c8",
+                "sha256:b2c5edc4ac10a7ef6605a966c58929ec6c1bd0917fb8c15cb3363f65aa40e677",
+                "sha256:b4d33f418f46362995f1e9d4f3a35a1b6322cb959c31d88ae56b0298e1c22357",
+                "sha256:b91cbc4b195444e7e258ba27ac33769c41b94967919f10037e6355e998af255c",
+                "sha256:c74880fc64d4958159fbd537a091d2a585448a8f8508bf248d72112723974cbd",
+                "sha256:c901df83d097649e257e803be22592aedfd5182f07b3cc87d640bbb9afd50f49",
+                "sha256:cac99918c7bba15302a2d81f0312c08054a3359eaa1929c7e4b26ebe41e9b286",
+                "sha256:cc4f1358cb0c78edef3ed237ef2c86056206bb8d9140e73b6b89fbcfcbdd40e1",
+                "sha256:ccd341521be3d1b3daeb41960ae94a5e87abe2f46f17224ba5d6f2b8398016cf",
+                "sha256:ce4b94265ca988c3f8e479e741693d143026632672e3ff924f25fab50518dd51",
+                "sha256:cf271892d13e43bc2b51e6908ec9a6a5094a4df1d8af0bfc360088ee6c684409",
+                "sha256:d5ae728ff3b5401cc320d792866987e7e7e880e6ebd24433b70a33b643bb0384",
+                "sha256:d71eec7d83298f1af3326ce0ff1d0ea83c7cb98f72b577097f9083b20bdaf05e",
+                "sha256:d898fe162d26929b5960e4e138651f7427048e72c853607f2b200909794ed978",
+                "sha256:d89d7b2974cae412400e88f35d86af72208e1ede1a541954af5d944a8ba46c57",
+                "sha256:dfa8fe35a0bb90382837b238fff375de15f0dcdb9ae68ff85f7a63649c98527e",
+                "sha256:e0be5efd5127542ef31f165de269f77560d6cdef525fffa446de6f7e9186cfb2",
+                "sha256:fdfafb32984684eb03c2d83e1e51f64f0906b11e64482df3c5db936ce3839d48",
+                "sha256:ff7687ca3d7028d8a5f0ebae95a6e4827c5616b31a4ee1192bdfde697db110d4"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.8'",
+            "version": "==7.4.4"
+        }
+    }
 }

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "e56f5ef6dbdc2b88d06fc0061d848be8ff848a2b2a39bc229af830b0572a62c5"
+            "sha256": "6523d852957dd4501f1f26f2fbbb15b298a712703a26077f1252bf7ff11f91b0"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -224,11 +224,11 @@
         },
         "idna": {
             "hashes": [
-                "sha256:050b4e5baadcd44d760cedbd2b8e639f2ff89bbc7a5730fcc662954303377aac",
-                "sha256:d838c2c0ed6fced7693d5e8ab8e734d5f8fda53a039c0164afb0b82e771e3603"
+                "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9",
+                "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==3.8"
+            "version": "==3.10"
         },
         "importlib-resources": {
             "hashes": [
@@ -402,6 +402,15 @@
             "markers": "python_version >= '3.6'",
             "version": "==2.8.0"
         },
+        "setuptools": {
+            "hashes": [
+                "sha256:54faa7f2e8d2d11bcd2c07bed282eef1046b5c080d1c32add737d7b5817b1ad4",
+                "sha256:f211a66637b8fa059bb28183da127d4e86396c991a942b028c6650d4319c3fd0"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.8'",
+            "version": "==70.0.0"
+        },
         "six": {
             "hashes": [
                 "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
@@ -420,11 +429,11 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:a448b2f64d686155468037e1ace9f2d2199776e17f0a46610480d311f73e3472",
-                "sha256:dd505485549a7a552833da5e6063639d0d177c04f23bc3864e41e5dc5f612168"
+                "sha256:ca899ca043dcb1bafa3e262d73aa25c465bfb49e0bd9dd5d59f1d0acba2f8fac",
+                "sha256:e7d814a81dad81e6caf2ec9fdedb284ecc9c73076b62654547cc64ccdcae26e9"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==2.2.2"
+            "version": "==2.2.3"
         },
         "werkzeug": {
             "hashes": [

--- a/docker-test.yaml
+++ b/docker-test.yaml
@@ -1,9 +1,5 @@
 schemaVersion: "2.0.0"
 commandTests:
-  - name: "gunicorn flask"
-    command: "which"
-    args: ["gunicorn"]
-    expectedOutput: ["/usr/local/bin/gunicorn"]
   - name: "python"
     command: "which"
     args: ["python"]


### PR DESCRIPTION
## :eyes: Purpose

- Originally, this PR aimed to mitigate CVE-2024-6345, but as development on this branch continued, other issues became clear. They are:
     - Fix the broken pipenv run test command.
     - Fix the broken docker container test.

## :recycle: What’s changed

- In the test cicd workflow, Python was bumped to match the requirements of the project.
- The version of setuptools was bumped to 70.0.0 to mitgate a cve.
- The package `coverage` was added to the requirements file.
- The container structure test was amended to include the correct image location and sha version to pin the dependency.
- The gunicorn binary was removed from the container structure test as it’s managed by pipenv so the location of the binary changes on each build.

## :memo: Notes

-