### PR TITLE
:sparkles: Hardcode aws region for easier duplication

### DIFF
--- a/.github/workflows/cicd-deploy-to-dev.yml
+++ b/.github/workflows/cicd-deploy-to-dev.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
         with:
           role-to-assume: ${{ secrets.DEV_ECR_ROLE_TO_ASSUME }}
-          aws-region: ${{ vars.DEV_ECR_REGION }}
+          aws-region: "eu-west-2"
 
       - uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2.0.1
         id: login-ecr


### PR DESCRIPTION
Other repositories will use this value (which is normally entered manually into GitHub's variables). It makes more sense to simply hardcode this value as it improves downstream developer experience.
