### PR TITLE
:arrow_up: Upgrade trivy action version and fix db download issues

### DIFF
--- a/.github/workflows/cicd-trivy-container-scan.yml
+++ b/.github/workflows/cicd-trivy-container-scan.yml
@@ -25,11 +25,13 @@ jobs:
 
       - name: Trivy scan
         id: scan
-        uses: aquasecurity/trivy-action@d43c1f16c00cfd3978dde6c07f4bbcf9eb6993ca # v0.16.1
+        uses: aquasecurity/trivy-action@6e7b7d1fd3e4fef0c5fa8cce1229c54b2c9bd0d8 # v0.16.1
         with:
           image-ref: "localbuild/testimage:latest"
           format: "sarif"
           output: "results.sarif"
+        env:
+          ACTIONS_RUNTIME_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v3


### PR DESCRIPTION
A potential fix was outlined in the bug highlighted here: `https://github.com/aquasecurity/trivy-action/issues/389` 