### PR TITLE
:wrench: Use the user id rather than name

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ WORKDIR /home/operations-engineering-application
 RUN chown -R appuser:appgroup /home/operations-engineering-application
 
 # Switch to non-root user
-USER appuser
+USER 1051
 
 # Copy Pipfile and Pipfile.lock
 COPY --chown=appuser:appgroup Pipfile Pipfile.lock ./


### PR DESCRIPTION
This is required in Cloud Platform. Attempts to deploy containers using the name will fail.
