### PR TITLE
:wrench: Correct the trivy scanner container version

### DIFF
--- a/.github/workflows/cicd-trivy-container-scan.yml
+++ b/.github/workflows/cicd-trivy-container-scan.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Trivy scan
         id: scan
-        uses: aquasecurity/trivy-action@6e7b7d1fd3e4fef0c5fa8cce1229c54b2c9bd0d8 # v0.16.1
+        uses: aquasecurity/trivy-action@d43c1f16c00cfd3978dde6c07f4bbcf9eb6993ca # v0.16.1
         with:
           image-ref: "localbuild/testimage:latest"
           format: "sarif"


### PR DESCRIPTION
For some reason this was incorrect and was failing to pull down.
